### PR TITLE
Fix error when there is an array with null value for treatment

### DIFF
--- a/lib/turkserver.coffee
+++ b/lib/turkserver.coffee
@@ -124,6 +124,7 @@ Meteor.publish null, ->
   return cursors
 
 Meteor.publish "tsTreatments", (names) ->
+  return [] unless names? and names[0]?
   check(names, [String]);
   return Treatments.find({name: { $in: names }});
 


### PR DESCRIPTION
A quick fix for throwing errors when a user that is logged in but has a [ null ] array of treatments. As per @mizzao think that would be safe to merge and guard against query errors in case that names is ill-defined (since it's coming from the client).
