### PR TITLE
Fix numberic value reading issue - cross browser

### DIFF
--- a/admin/experimentAdmin.coffee
+++ b/admin/experimentAdmin.coffee
@@ -5,9 +5,9 @@ Template.tsAdminExperiments.events
     e.preventDefault()
 
     Router.go "tsExperiments",
-      days: t.find("input[name=filter_days]").valueAsNumber ||
+      days: parseInt(t.find("input[name=filter_days]").value) ||
         TurkServer.adminSettings.defaultDaysThreshold
-      limit: t.find("input[name=filter_limit]").valueAsNumber ||
+      limit: parseInt(t.find("input[name=filter_limit]").value) ||
         TurkServer.adminSettings.defaultLimit
 
   "click .-ts-stop-experiment": ->

--- a/admin/mturkAdmin.coffee
+++ b/admin/mturkAdmin.coffee
@@ -36,10 +36,10 @@ Template.tsAdminNewHitType.events =
       Title: tmpl.find("input[name=title]").value
       Description: tmpl.find("textarea[name=desc]").value
       Keywords: tmpl.find("input[name=keywords]").value
-      Reward: tmpl.find("input[name=reward]").valueAsNumber
+      Reward: parseFloat(tmpl.find("input[name=reward]").value)
       QualificationRequirement: $(tmpl.find("select[name=quals]")).val()
-      AssignmentDurationInSeconds: tmpl.find("input[name=duration]").valueAsNumber
-      AutoApprovalDelayInSeconds: tmpl.find("input[name=delay]").valueAsNumber
+      AssignmentDurationInSeconds: parseInt(tmpl.find("input[name=duration]").value)
+      AutoApprovalDelayInSeconds: parseInt(tmpl.find("input[name=delay]").value)
 
     Session.set("_tsSelectedHITType", id)
 

--- a/admin/util.coffee
+++ b/admin/util.coffee
@@ -79,7 +79,7 @@ Template.tsAdminInstance.helpers
 Template.tsAdminPayBonus.events
   "submit form": (e, t) ->
     e.preventDefault()
-    amount = t.find("input[name=amount]").valueAsNumber
+    amount = parseFloat(t.find("input[name=amount]").value)
     reason = t.find("textarea[name=reason]").value
 
     $(t.firstNode).closest(".bootbox.modal").modal('hide')


### PR DESCRIPTION
Replace `ValueAsNumber` for global browser support.

Cross browser test:

Edge  -  25.1x
IE  -  11.1x
Chrome   - 49.0.x
Fire fox   -  45.0.1
Opara  -  36.0.x
